### PR TITLE
Fix regex warning with HA 2024.2.0

### DIFF
--- a/custom_components/daikin_residential_altherma/daikin_api.py
+++ b/custom_components/daikin_residential_altherma/daikin_api.py
@@ -307,7 +307,7 @@ class DaikinApi:
             resp = await self.hass.async_add_executor_job(func)
             body = resp.text
             # _LOGGER.debug('BODY: %s', body)
-            regex = "(\d+-\d-\d+)"
+            regex = '(\\d+-\\d-\\d+)'
             ms = re.search(regex, body)
             version = ms[0]
             _LOGGER.debug("VERSION: %s", version)


### PR DESCRIPTION
    * custom_components/daikin_residential_altherma/daikin_api.py: